### PR TITLE
[WIP] GTest matcher integration

### DIFF
--- a/test/adapter-tests/gtest/main.cpp
+++ b/test/adapter-tests/gtest/main.cpp
@@ -6,7 +6,8 @@
 #include "mimic++/Mock.hpp"
 #include "mimic++/adapters/gtest.hpp"
 
-#include "gtest/gtest-spi.h"
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest-spi.h>
 
 namespace
 {
@@ -111,4 +112,31 @@ TEST(
 	EXPECT_FATAL_FAILURE(
 		EXPECT_ANY_THROW(mimicpp::detail::gtest::send_fail("Test")),
 		"Test");
+}
+
+TEST(
+	GTestMatcher,
+	ComparisonMatcher
+)
+{
+	static_assert(
+		mimicpp::matcher_for<
+			decltype(::testing::Ge(42)),
+			const int&>);
+
+	mimicpp::Mock<void(const int&)> mock{};
+
+	SCOPED_EXP mock.expect_call(::testing::Ge(42));
+	mock(1337);
+}
+
+TEST(
+	GTestMatcher,
+	GenericMatcher
+)
+{
+	static_assert(
+		mimicpp::matcher_for<
+			decltype(::testing::ContainsRegex("Hello, \\d")),
+			const std::string&>);
 }


### PR DESCRIPTION
As with the "catch2-matcher-integration" experimental feature, it would probably be beneficial to add a native integration of the gtest matchers. Unfortunatly that seems to be more complicated.

The current state integrates the ``gtest`` matchers, but those are just a very small sub-set of all available matchers. Most of them are part of ``gmock``, with an completetly different architecture. ``gmock`` seems to provide tools to unify both worlds, but ``gtest`` by itself is quite useless. 
e.g. ``testing::MatcherCast``, ``testing::SafeMatcherCast``, ``testing::matches``

Definitely more research required.