### PR TITLE
Use ``matches::str::eq`` for string arguments when in-place expectation is used

### DIFF
--- a/include/mimic++/ExpectationBuilder.hpp
+++ b/include/mimic++/ExpectationBuilder.hpp
@@ -200,9 +200,21 @@ namespace mimicpp::detail
 			std::remove_cvref_t<Arg>,
 			signature_param_type_t<index, Signature>>
 	[[nodiscard]]
-	constexpr auto make_arg_policy(Arg&& arg, [[maybe_unused]] const priority_tag<2>)
+	constexpr auto make_arg_policy(Arg&& arg, [[maybe_unused]] const priority_tag<3>)
 	{
 		return expect::arg<index>(std::forward<Arg>(arg));
+	}
+
+	template <
+		typename Signature,
+		std::size_t index,
+		string Arg>
+		requires string<signature_param_type_t<index, Signature>>
+	[[nodiscard]]
+	constexpr auto make_arg_policy(Arg&& arg, [[maybe_unused]] const priority_tag<2>)
+	{
+		return expect::arg<index>(
+			matches::str::eq(std::forward<Arg>(arg)));
 	}
 
 	template <typename Signature, std::size_t index, std::equality_comparable_with<signature_param_type_t<index, Signature>> Arg>
@@ -238,7 +250,7 @@ namespace mimicpp::detail
 			&& ...
 			&& detail::make_arg_policy<Signature, indices>(
 				std::forward<Args>(args),
-				priority_tag<2>{}));
+				priority_tag<3>{}));
 	}
 
 	template <typename Signature, typename... Args>

--- a/include/mimic++/Mock.hpp
+++ b/include/mimic++/Mock.hpp
@@ -15,10 +15,6 @@
 
 namespace mimicpp::detail
 {
-	template <typename T, typename Target>
-	concept requirement_for = std::equality_comparable_with<T, Target>
-							|| matcher_for<std::remove_cvref_t<T>, Target>;
-
 	template <ValueCategory category, Constness constness, typename Return, typename... Params>
 	class BasicMockFrontend
 	{

--- a/test/unit-tests/Mock.cpp
+++ b/test/unit-tests/Mock.cpp
@@ -887,3 +887,27 @@ TEST_CASE(
 	REQUIRE(firstExpectation.is_satisfied());
 	REQUIRE(secondExpectation.is_satisfied());
 }
+
+TEST_CASE("Mocks support direct argument matchers.")
+{
+	SECTION("For arguments, which support operator ==")
+	{
+		Mock<void(int)> mock{};
+		SCOPED_EXP mock.expect_call(1337);
+		mock(1337);
+	}
+
+	SECTION("For strings.")
+	{
+		Mock<void(const char*)> mock{};
+		SCOPED_EXP mock.expect_call("Hello, World!");
+		mock("Hello, World!");
+	}
+
+	SECTION("With explicit matchers.")
+	{
+		Mock<void(int)> mock{};
+		SCOPED_EXP mock.expect_call(matches::ne(42));
+		mock(1337);
+	}
+}


### PR DESCRIPTION
The following test currently fails:
```cpp
Mock<void(const char*)> mock{};
SCOPED_EXP mock.expect_call("Hello, World!");
mock("Hello, World!");
```
This is rather unexpected, as the intent is to compare the strings and not the pointers. This changes this.

I wouldn't consider this a bug, it's a respecification.