### PR TITLE
Split warnings from setup function into target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ else()
 	set(IS_TOP_LEVEL_PROJECT OFF)
 endif()
 
+include(EnableWarnings)
+
 OPTION(MIMICPP_BUILD_TESTS "Determines, whether the tests shall be built." ${IS_TOP_LEVEL_PROJECT})
 if (MIMICPP_BUILD_TESTS)
 	include(CTest)

--- a/cmake/EnableSanitizers.cmake
+++ b/cmake/EnableSanitizers.cmake
@@ -3,13 +3,10 @@
 #    (See accompanying file LICENSE_1_0.txt or copy at
 #         https://www.boost.org/LICENSE_1_0.txt)
 
-
-function(setup_test_target TARGET_NAME)
-
+function(enable_sanitizers TARGET_NAME)
 	find_package(sanitizers-cmake)
 
 	if (SANITIZE_ADDRESS)
-
 		# workaround linker errors on msvc
 		# see: https://learn.microsoft.com/en-us/answers/questions/864574/enabling-address-sanitizer-results-in-error-lnk203
 		target_compile_definitions(
@@ -18,32 +15,7 @@ function(setup_test_target TARGET_NAME)
 			$<$<CXX_COMPILER_ID:MSVC>:_DISABLE_VECTOR_ANNOTATION>
 			$<$<CXX_COMPILER_ID:MSVC>:_DISABLE_STRING_ANNOTATION>
 		)
-
 	endif()
 
 	add_sanitizers(${TARGET_NAME})
-
-	# We need to circumvent the huge nonsense warnings from clang-cl
-	# see: https://discourse.cmake.org/t/wall-with-visual-studio-clang-toolchain-results-in-way-too-many-warnings/7927
-	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
-		AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-
-		set(WARNING_FLAGS /W4 -Wextra -Wpedantic -Werror -Wno-unknown-attributes)
-
-	else()
-
-		set(WARNING_FLAGS
-			$<IF:$<CXX_COMPILER_ID:MSVC>,
-				/W4 /WX,
-				-Wall -Wextra -Wpedantic -Werror>
-		)
-
-	endif()
-
-	target_compile_options(
-		${TARGET_NAME}
-		PRIVATE
-		${WARNING_FLAGS}
-	)
-
 endfunction()

--- a/cmake/EnableWarnings.cmake
+++ b/cmake/EnableWarnings.cmake
@@ -1,0 +1,21 @@
+add_library(enable-warnings INTERFACE)
+
+# We need to circumvent the huge nonsense warnings from clang-cl
+# see: https://discourse.cmake.org/t/wall-with-visual-studio-clang-toolchain-results-in-way-too-many-warnings/7927
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+	AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+
+	set(WARNING_FLAGS /W4 -Wextra -Wpedantic -Werror -Wno-unknown-attributes)
+else()
+	set(WARNING_FLAGS
+		$<IF:$<CXX_COMPILER_ID:MSVC>,
+		/W4 /WX,
+		-Wall -Wextra -Wpedantic -Werror>
+	)
+endif()
+
+target_compile_options(
+	enable-warnings
+	INTERFACE
+	${WARNING_FLAGS}
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,12 +15,13 @@ add_executable(
 	"Watcher.cpp"
 )
 
-include(SetupTestTarget)
-setup_test_target(mimicpp-examples)
+include(EnableSanitizers)
+enable_sanitizers(mimicpp-examples)
 
 target_link_libraries(
 	mimicpp-examples
 	PRIVATE
+	enable-warnings
 	mimicpp::mimicpp
 	Catch2::Catch2WithMain
 )

--- a/test/adapter-tests/boost-test/CMakeLists.txt
+++ b/test/adapter-tests/boost-test/CMakeLists.txt
@@ -3,8 +3,14 @@ add_executable(
 	"main.cpp"
 )
 
-include(SetupTestTarget)
-setup_test_target(mimicpp-adapter-tests-boost-test)
+include(EnableSanitizers)
+enable_sanitizers(mimicpp-adapter-tests-boost-test)
+
+target_link_libraries(
+	mimicpp-adapter-tests-boost-test
+	PRIVATE
+	enable-warnings
+)
 
 if (WIN32)
 	set(BOOST_ARCHIVE_URL "https://github.com/boostorg/boost/releases/download/boost-1.85.0/boost-1.85.0-cmake.zip")

--- a/test/adapter-tests/catch2/CMakeLists.txt
+++ b/test/adapter-tests/catch2/CMakeLists.txt
@@ -5,14 +5,15 @@ add_executable(
 	"main.cpp"
 )
 
-include(SetupTestTarget)
-setup_test_target(mimicpp-adapter-tests-catch2)
+include(EnableSanitizers)
+enable_sanitizers(mimicpp-adapter-tests-catch2)
 
 target_link_libraries(
 	mimicpp-adapter-tests-catch2
 	PRIVATE
 	mimicpp::mimicpp
 	Catch2::Catch2WithMain
+	enable-warnings
 )
 
 catch_discover_tests(mimicpp-adapter-tests-catch2)

--- a/test/adapter-tests/gtest/CMakeLists.txt
+++ b/test/adapter-tests/gtest/CMakeLists.txt
@@ -3,8 +3,8 @@ add_executable(
 	"main.cpp"
 )
 
-include(SetupTestTarget)
-setup_test_target(mimicpp-adapter-tests-gtest)
+include(EnableSanitizers)
+enable_sanitizers(mimicpp-adapter-tests-gtest)
 
 CPMAddPackage(
 	NAME GTest
@@ -21,6 +21,7 @@ target_link_libraries(
 	PRIVATE
 	mimicpp::mimicpp
 	GTest::gtest_main
+	enable-warnings
 )
 
 include(GoogleTest)

--- a/test/unit-tests/CMakeLists.txt
+++ b/test/unit-tests/CMakeLists.txt
@@ -24,8 +24,8 @@ add_executable(
 
 add_subdirectory(matchers)
 
-include(SetupTestTarget)
-setup_test_target(mimicpp-tests)
+include(EnableSanitizers)
+enable_sanitizers(mimicpp-tests)
 
 target_compile_options(
 	mimicpp
@@ -41,6 +41,7 @@ target_link_libraries(
 	mimicpp::mimicpp
 	Catch2::Catch2WithMain
 	trompeloeil::trompeloeil
+	enable-warnings
 )
 
 catch_discover_tests(mimicpp-tests)


### PR DESCRIPTION
Split sanitizer and warning related options into an interface target and a sanitizer function.

The sanitizer enabler could not be used on the interface target, because add_sanitizer does not allow it.